### PR TITLE
improve accuracy computation and plotting

### DIFF
--- a/mvEEG/interpreter.py
+++ b/mvEEG/interpreter.py
@@ -211,7 +211,7 @@ class Interpreter:
             plt.setp(ax.get_yticklabels(), fontsize=14)
             plt.xlim(min(t), max(t))
             plt.ylim(ylim)
-            ax.legend(loc="lower right", frameon=False, fontsize=11)
+            # ax.legend(loc="lower right", frameon=False, fontsize=11)
 
             # labelling
             ax.set_xlabel("Time from stimulus onset (ms)", fontsize=14)


### PR DESCRIPTION
This PR contains 2 fixes:

1. changes accuracy computation to only occur for test trials whose labels exist in the training set. I.e., if you train on classes A and B, and test on A,B,C and D, only performance on A and B trials will be considered for accuracy (though every other metric will still be computed on all 4, including which classes were predicted for C and D). Closes #9 .

Old:
<img width="497" alt="Screenshot 2024-10-08 at 3 27 12 PM" src="https://github.com/user-attachments/assets/d9d3b85d-7702-4f8b-bf4a-45f34bc29587">

New:
<img width="497" alt="Screenshot 2024-10-08 at 4 05 44 PM" src="https://github.com/user-attachments/assets/1d738358-d048-4ade-ac51-ca4914e89d32">



2. removes and empty legend call from the interpreters plot_acc function, which was printing an unnecessary warning.
