### PR TITLE
minor improvements to Wrangler object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,6 @@ cython_debug/
 
 #vscode
 .vscode
+
+# manual
+test_notebook.ipynb

--- a/mvEEG/wrangler.py
+++ b/mvEEG/wrangler.py
@@ -304,8 +304,35 @@ class Wrangler:
         """
         map_dict = {self.condition_dict[k]: v for k, v in self.group_dict.items()}
         return np.vectorize(map_dict.get)(ydata)
+    
+    @staticmethod
+    def _move_element(a,b,index,axis=0):
+        """
+        moves an element from one numpy array to another along the specified dimension
+        """
+        b = np.append(b,a[index],axis=axis)
+        a = np.delete(a,index,axis=axis)
+        return a,b
 
-    def bin_and_split(self, xdata, ydata,test_size=0.2):
+    def _equalize_and_move_conditions(self, x_train, x_test, y_train, y_test):
+        """
+        moves extra training trials to testing set
+        """
+
+        train_labels,train_counts = np.unique(y_train,return_counts=True)
+        num_to_move = train_counts - train_counts.min()
+        for val,n_move in zip(train_labels,num_to_move):
+            if val in y_test:
+
+                move_ixs = np.random.choice(np.where(y_test == val)[0],n_move,replace=False)
+
+                x_train,x_test = self._move_element(x_train,x_test,move_ixs)
+                y_train,y_test = self._move_element(y_train,y_test,move_ixs)
+
+        return x_train, x_test, y_train, y_test
+
+
+    def bin_and_split(self, xdata, ydata,test_size=0.2,equalize_train=True,equalize_test=True):
         """
         generator to handle trial binning and splitting into training and testing sets
         """
@@ -321,8 +348,10 @@ class Wrangler:
                 x_train,y_train = self._select_labels(x_train,y_train,self.training_conditions,code_dict=self.group_dict)
                 x_test,y_test = self._select_labels(x_test,y_test,self.testing_conditions,code_dict=self.group_dict)
 
-            # equalize conditions one more time to avoid imabalances
-            x_train,y_train = self._equalize_conditions(x_train,y_train)
-            x_test,y_test = self._equalize_conditions(x_test,y_test)
+            if equalize_train:
+                x_train,x_test,y_train,y_test = self._equalize_and_move_conditions(x_train,x_test,y_train,y_test)
+
+            if equalize_test:
+                x_test,y_test = self._equalize_conditions(x_test,y_test)
 
             yield x_train, x_test, y_train, y_test

--- a/mvEEG/wrangler.py
+++ b/mvEEG/wrangler.py
@@ -172,7 +172,12 @@ class Wrangler:
             assert (
                 epochs.info["sfreq"] % self.sfreq == 0
             ), "Cannot resample to desired frequency"
-            epochs = epochs.decimate(self.sfreq)
+
+            assert (
+                epochs.info["sfreq"] > self.sfreq
+            ), "Cannot upsample"
+            epochs = epochs.decimate(epochs.info["sfreq"] / self.sfreq)
+            
 
         if self.trim_timepoints is not None:  # crop trial duration
             epochs.crop(

--- a/mvEEG/wrangler.py
+++ b/mvEEG/wrangler.py
@@ -318,5 +318,8 @@ class Wrangler:
                 x_train,y_train = self._select_labels(x_train,y_train,self.training_conditions,code_dict=self.group_dict)
                 x_test,y_test = self._select_labels(x_test,y_test,self.testing_conditions,code_dict=self.group_dict)
 
+            # equalize conditions one more time to avoid imabalances
+            x_train,y_train = self._equalize_conditions(x_train,y_train)
+            x_test,y_test = self._equalize_conditions(x_test,y_test)
 
             yield x_train, x_test, y_train, y_test

--- a/mvEEG/wrangler.py
+++ b/mvEEG/wrangler.py
@@ -25,8 +25,8 @@ class Wrangler:
         self,
         data_dir,
         experiment_name,
-        included_subs: list = [],
-        dropped_subs: list = [],
+        included_subs: list | None = None,
+        dropped_subs: list | None = None,
         dropped_chans: dict = dropped_chans_default,
         trim_timepoints=None,
         t_win: int = 50,
@@ -52,7 +52,8 @@ class Wrangler:
 
         self.rng = np.random.default_rng(RANDOM_SEED)
 
-        if len(included_subs) == 0:  # default to all subs
+        if included_subs is not None:  # default to all subs
+            dropped_subs = [] if dropped_subs is None else dropped_subs
             self.subs = mne_bids.get_entity_vals(
                 self.bids_path.root, "subject", ignore_subjects=dropped_subs
             )

--- a/mvEEG/wrangler.py
+++ b/mvEEG/wrangler.py
@@ -29,7 +29,6 @@ class Wrangler:
         dropped_subs: list = [],
         dropped_chans: dict = dropped_chans_default,
         trim_timepoints=None,
-        sfreq: int = 1000,
         t_win: int = 50,
         t_step: int = 25,
         trial_bin_size: int = 20,
@@ -64,7 +63,6 @@ class Wrangler:
                                  f"subjects: {[sub for sub in dropped_subs if sub in included_subs]}")
 
         self.nsub = len(self.subs)
-        self.sfreq = sfreq
         self.trim_timepoints = trim_timepoints
         self.t_win = t_win
         self.t_step = t_step
@@ -168,15 +166,6 @@ class Wrangler:
         chans_to_drop = [chan for chan in chans_to_drop if chan in epochs.ch_names]
         epochs.drop_channels(chans_to_drop)
 
-        if self.sfreq != epochs.info["sfreq"]:  # resample if high sampling frequency
-            assert (
-                epochs.info["sfreq"] % self.sfreq == 0
-            ), "Cannot resample to desired frequency"
-
-            assert (
-                epochs.info["sfreq"] > self.sfreq
-            ), "Cannot upsample"
-            epochs = epochs.decimate(epochs.info["sfreq"] / self.sfreq)
             
 
         if self.trim_timepoints is not None:  # crop trial duration

--- a/mvEEG/wrangler.py
+++ b/mvEEG/wrangler.py
@@ -123,8 +123,8 @@ class Wrangler:
         if testing_groups is None:
             testing_groups = training_groups
 
-        training_groups = [cond.split("/") if "/" in cond else cond for cond in training_groups] # split into subgroups
-        testing_groups = [cond.split("/") if "/" in cond else cond for cond in testing_groups]
+        training_groups = [cond.split("/") if "/" in cond else [cond] for cond in training_groups] # split into subgroups
+        testing_groups = [cond.split("/") if "/" in cond else [cond] for cond in testing_groups]
 
 
         self.training_conditions = []

--- a/mvEEG/wrangler.py
+++ b/mvEEG/wrangler.py
@@ -25,6 +25,7 @@ class Wrangler:
         self,
         data_dir,
         experiment_name,
+        included_subs: list = [],
         dropped_subs: list = [],
         dropped_chans: dict = dropped_chans_default,
         trim_timepoints=None,
@@ -52,9 +53,16 @@ class Wrangler:
 
         self.rng = np.random.default_rng(RANDOM_SEED)
 
-        self.subs = mne_bids.get_entity_vals(
-            self.bids_path.root, "subject", ignore_subjects=dropped_subs
-        )
+        if len(included_subs) == 0:  # default to all subs
+            self.subs = mne_bids.get_entity_vals(
+                self.bids_path.root, "subject", ignore_subjects=dropped_subs
+            )
+        else:
+            self.subs = included_subs
+            if any([sub in included_subs for sub in dropped_subs]):
+                raise ValueError("Included and dropped subjects overlap"+
+                                 f"subjects: {[sub for sub in dropped_subs if sub in included_subs]}")
+
         self.nsub = len(self.subs)
         self.sfreq = sfreq
         self.trim_timepoints = trim_timepoints


### PR DESCRIPTION
- ensure that training/testing are being done on an equal number of conditions by re-equalizing after split
    - i.e. if training is [0,0,1,1,1] it is now [0,0,1,1] to avoid bias
    - good idea?
- A couple overrides for wrangler.subs
    - give included_subs to only run on a subset of subject directories
    - give dropped_subs to run on all subject directories except a subset
    - give neither to run on everything
- Remove resampling code
- other minor bug fixes
